### PR TITLE
Make type_field removal optional

### DIFF
--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -55,6 +55,7 @@ class OneOfSchema(Schema):
     setting `type_field` class property.
     """
     type_field = 'type'
+    type_field_remove = True
     type_schemas = []
 
     def get_obj_type(self, obj):
@@ -134,7 +135,11 @@ class OneOfSchema(Schema):
 
         data = dict(data)
 
-        data_type = data.pop(self.type_field, None)
+        if self.type_field_remove:
+            data_type = data.pop(self.type_field, None)
+        else:
+            data_type = data[self.type_field]
+
         if not data_type:
             return UnmarshalResult({}, {
                 self.type_field: ['Missing data for required field.']

--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -135,10 +135,9 @@ class OneOfSchema(Schema):
 
         data = dict(data)
 
-        if self.type_field_remove:
-            data_type = data.pop(self.type_field, None)
-        else:
-            data_type = data[self.type_field]
+        data_type = data.get(self.type_field)
+        if self.type_field in data and self.type_field_remove:
+            data.pop(self.type_field)
 
         if not data_type:
             return UnmarshalResult({}, {

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -149,6 +149,35 @@ class TestOneOfSchema:
         TestSchema().load({'type': 'Bar', 'bar': 123})
         assert 'type' not in Nonlocal.data
 
+    def test_load_keeps_type_field(self):
+        class Nonlocal(object):
+            data = None
+            type = None
+
+        class MySchema(m.Schema):
+            def load(self, data, *args, **kwargs):
+                Nonlocal.data = data
+                return super(MySchema, self).load(data, *args, **kwargs)
+
+        class FooSchema(MySchema):
+            foo = f.String(required=True)
+
+        class BarSchema(MySchema):
+            bar = f.Integer(required=True)
+
+        class TestSchema(OneOfSchema):
+            type_field_remove = False
+            type_schemas = {
+                'Foo': FooSchema,
+                'Bar': BarSchema,
+            }
+
+        TestSchema().load({'type': 'Foo', 'foo': 'hello'})
+        assert 'type' in Nonlocal.data
+
+        TestSchema().load({'type': 'Bar', 'bar': 123})
+        assert 'type' in Nonlocal.data
+
     def test_load_non_dict(self):
         result = MySchema().load(123)
         assert {} != result.errors

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -173,10 +173,10 @@ class TestOneOfSchema:
             }
 
         TestSchema().load({'type': 'Foo', 'foo': 'hello'})
-        assert 'type' in Nonlocal.data
+        assert Nonlocal.data['type'] == 'Foo'
 
         TestSchema().load({'type': 'Bar', 'bar': 123})
-        assert 'type' in Nonlocal.data
+        assert Nonlocal.data['type'] == 'Bar'
 
     def test_load_non_dict(self):
         result = MySchema().load(123)


### PR DESCRIPTION
I have a use case for this, after loading the schema we still need to keep the type field.