### PR TITLE
Add default schema configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,22 @@ You can customize type field with `type_field` class property:
         MyUberSchema().dump([Foo(foo='hello'), Bar(bar=123)], many=True).data
         # => [{'object_type': 'Foo', 'foo': 'hello'}, {'object_type': 'Bar', 'bar': 123}]
 
+You can set a default schema with `default_schema` class property:
+
+.. code:: python
+
+        class MyUberSchema(OneOfSchema):
+            default_schema = BazSchema
+            type_field = 'object_type'
+            type_schemas = {
+                'Foo': FooSchema,
+                'Bar': BarSchema,
+            }
+
+        MyUberSchema().dump([Foo(foo='hello'), Bar(bar=123), Baz(baz='default')], many=True).data
+        # => [{'object_type': 'Foo', 'foo': 'hello'}, {'object_type': 'Bar', 'bar': 123}, {'object_type': 'Baz', 'baz': 'default'}]
+
+
 You can use resulting schema everywhere marshmallow.Schema can be used, e.g.
 
 .. code:: python

--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -57,6 +57,7 @@ class OneOfSchema(Schema):
     type_field = 'type'
     type_field_remove = True
     type_schemas = []
+    default_schema = None
 
     def get_obj_type(self, obj):
         """Returns name of object schema"""
@@ -90,7 +91,7 @@ class OneOfSchema(Schema):
                 '_schema': 'Unknown object class: %s' % obj.__class__.__name__
             })
 
-        type_schema = self.type_schemas.get(obj_type)
+        type_schema = self.type_schemas.get(obj_type, self.default_schema)
         if not type_schema:
             return MarshalResult(None, {
                 '_schema': 'Unsupported object type: %s' % obj_type
@@ -144,7 +145,7 @@ class OneOfSchema(Schema):
                 self.type_field: ['Missing data for required field.']
             })
 
-        type_schema = self.type_schemas.get(data_type)
+        type_schema = self.type_schemas.get(data_type, self.default_schema)
         if not type_schema:
             return UnmarshalResult({}, {
                 self.type_field: ['Unsupported value: %s' % data_type],


### PR DESCRIPTION
The default_schema class attribute can be used in cases where only some
of the types needs special handling.