### PR TITLE
Return type in dump() for objects without any attributes

### DIFF
--- a/marshmallow_oneofschema/one_of_schema.py
+++ b/marshmallow_oneofschema/one_of_schema.py
@@ -110,7 +110,7 @@ class OneOfSchema(Schema):
         result = schema.dump(
             obj, many=False, update_fields=update_fields, **kwargs
         )
-        if result:
+        if result is not None:
             result[self.type_field] = obj_type
         return result
 

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -67,11 +67,22 @@ class BazSchema(m.Schema):
         return Baz(**data)
 
 
+class Empty(object):
+    pass
+
+
+class EmptySchema(m.Schema):
+    @m.post_load
+    def make_empty(self, data):
+        return Empty(**data)
+
+
 class MySchema(OneOfSchema):
     type_schemas = {
         'Foo': FooSchema,
         'Bar': BarSchema,
         'Baz': BazSchema,
+        'Empty': EmptySchema,
     }
 
 
@@ -92,6 +103,10 @@ class TestOneOfSchema:
         result = MySchema(many=True).dump([Foo('hello'), Bar(123)])
         assert [{'type': 'Foo', 'value': 'hello'},
                 {'type': 'Bar', 'value': 123}] == result
+
+    def test_dump_with_empty_keeps_type(self):
+        result = MySchema().dump(Empty())
+        assert {'type': 'Empty'} == result
 
     def test_load(self):
         foo_result = MySchema().load({'type': 'Foo', 'value': 'world'})


### PR DESCRIPTION
First of all, thanks for the great library.

I'm running into an issue where the 'type' attribute is omitted in dump() for objects that don't have any attributes in them. I'm guessing this is unintended behavior as this breaks the dumping/loading round trip. Please see the PR. Also created a test.